### PR TITLE
[Update] fix cats.py to solve EC2 in Project 2

### DIFF
--- a/projects/cats/cats.py
+++ b/projects/cats/cats.py
@@ -101,8 +101,9 @@ def autocorrect(user_word, valid_words, diff_function, limit):
     "*** YOUR CODE HERE ***"
     if user_word in valid_words:
         return user_word
-    similar_word = min(valid_words, key=lambda w:diff_function(user_word, w, limit))
-    if diff_function(user_word, similar_word, limit) > limit:
+    words_diff = [diff_function(user_word, w, limit) for w in valid_words]
+    similar_word, similar_diff = min(zip(valid_words, words_diff), key=lambda item: item[1])
+    if similar_diff > limit:
         return user_word
     else:
         return similar_word
@@ -324,29 +325,30 @@ def memo(f):
 
 key_distance_diff = memo(key_distance_diff)
 key_distance_diff = count(key_distance_diff)
+memo_for_fa = {}
 
 def faster_autocorrect(user_word, valid_words, diff_function, limit):
     """A memoized version of the autocorrect function implemented above."""
 
     # BEGIN PROBLEM EC2
     "*** YOUR CODE HERE ***"
-    memo_for_fa = {}
-    if user_word in memo_for_fa:
-        return memo_for_fa[user_word]
+    idx = tuple([user_word, tuple(valid_words), diff_function, limit])
+    if user_word in valid_words:
+        return user_word
+    if idx in memo_for_fa:
+        return memo_for_fa[idx]
     else:
-        if user_word in valid_words:
+        # print("DEBUG: will is in the valid_words", "will" in valid_words)
+        # print("DEBUG: dist(woll, will) = ", diff_function(user_word, "will", limit))
+        # print("DEBUG: dist(woll, well) = ", diff_function(user_word, "well", limit))
+        words_diff = [diff_function(user_word, w, limit) for w in valid_words]
+        similar_word, similar_diff = min(zip(valid_words, words_diff), key=lambda item: item[1])
+        print("DEBUG:", similar_word)
+        if similar_diff > limit:
             ret = user_word
         else:
-            print("DEBUG: will is in the valid_words", "will" in valid_words)
-            print("DEBUG: dist(woll, will) = ", diff_function(user_word, "will", limit))
-            print("DEBUG: dist(woll, well) = ", diff_function(user_word, "well", limit))
-            similar_word = min(valid_words, key=lambda w:diff_function(user_word, w, limit))
-            print("DEBUG:", similar_word)
-            if diff_function(user_word, similar_word, limit) > limit:
-                ret = user_word
-            else:
-                ret = similar_word
-        memo_for_fa[user_word] = ret
+            ret = similar_word
+        memo_for_fa[idx] = ret
         return ret
     # END PROBLEM EC2
 


### PR DESCRIPTION
# Update faster_autocorrect and autocorrect functions to solve the Extra Credit Problem 2 in Project 2
**URL: https://inst.eecs.berkeley.edu/~cs61a/su20/proj/cats/#extra-credit-problem-2-efficiency-1-pt**

**The ok tests (`python3 ok -q EC2`) of original implement of faster_autocorrect is the following:**
```
>>> faster_autocorrect("woll", common_words, key_distance_diff, 4)
DEBUG: will is in the valid_words True
DEBUG: dist(woll, will) =  0.6834861261734088
DEBUG: dist(woll, well) =  2
DEBUG: will
'will'
>>> key_distance_diff.call_count <= 2000 #key_distance_diffs should be memoized, this is the first call to faster_autocorrect
False

# Error: expected
#     True
# but got
#     False
```
The main reason for this error is because we didn't record the diff_funcion result of similar_word in `similar_word = min(valid_words, key=lambda w:diff_function(user_word, w, limit))`, and we need to calculate it again to check the diff is larger than the limit. This cause one more function call of `diff_function` and exceeds the call_count requirements. Also, it's similar in the autocorrect function, so we update both for ok tests.

**However, only modifying the mentioned process may cause another Error:**
```
>>> faster_autocorrect("woll", common_words, key_distance_diff, 4)
'will'
>>> key_distance_diff.call_count #faster_autocorrect should be memoized and this is the second call
2000

# Error: expected
#     0
# but got
#     2000
```
This is because the ok test requires us to save the words we already call faster_autocorrect on. For the second function call with the same input parameters, we need to return the result directly. According to the video hint (https://www.youtube.com/watch?v=ZVvS_w4LNis, 11:05-12:40), we can define global variables to store the result of each function call. Since the results are related to all input parameters, a straightforward but not perfect idea is to convert them all to hashable data structures - tuple as an index. 

**By executing the command `python3 ok -q EC2`, we found that this implementation passed all 3 test cases.**
